### PR TITLE
Fixed tiny oversight and eval STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ test: {
                 "should reject baz": {
                     assert: {
                         invalid: {
-                            value: "bazn"
+                            value: "baz"
                             pass:  true
                         }
                     }


### PR DESCRIPTION
Got a little ahead of my self here and used the STDOUT from a
different `cue eval` execution.