### PR TITLE
update syntax for cue 0.4.2

### DIFF
--- a/test/testing.cue
+++ b/test/testing.cue
@@ -3,7 +3,7 @@ package test
 import "github.com/ipcf/testing"
 
 testing.T & {
-	BarBaz = =~"^([foo]|[bar])+$"
+	let BarBaz = =~"^([foo]|[bar])+$"
 
 	test: "BarBaz": {
 		[testing.NumDot]: subject: BarBaz
@@ -21,7 +21,7 @@ testing.T & {
 		"11": assert: notOk: {}
 	}
 
-	FooBar = close({
+	let FooBar = close({
 		thing:    string
 		greeting: "hey" | "hello"
 		result:   "\(greeting) \(thing)"
@@ -60,7 +60,7 @@ testing.T & {
 		"12": assert: notOk: "0f1"
 	}
 
-	someFailures = {
+	let someFailures = {
 		"0": {subject: string, assert: {ok: "shouldPass", pass: true}}
 		"1": {subject: string, assert: {notOk: "shouldFail", pass: false}}
 		"2": {subject: string, assert: {ok: 4, pass: false}}

--- a/testing.cue
+++ b/testing.cue
@@ -3,8 +3,8 @@ package testing
 T: {
 	test: Test
 	let test_ = test
-	FAIL: (checkTests & {passValue: false, "test": test_}).result
-	PASS: (checkTests & {passValue: true, "test":  test_}).result
+	FAIL: (#checkTests & {passValue: false, "test": test_}).result
+	PASS: (#checkTests & {passValue: true, "test":  test_}).result
 }
 
 NumDot: =~"^[0-9]+([.]?[0-9])*$"
@@ -23,7 +23,7 @@ Test: {
 	}
 }
 
-checkTests: {
+#checkTests: {
 	passValue?: bool
 	test:       Test
 	result: {
@@ -38,7 +38,7 @@ checkTests: {
 			}
 		}
 		for k, v in test_ if (k != "assert" && k != "subject") {
-			let failedTests = (checkTests & {test: v, passValue: passValue_}).result
+			let failedTests = (#checkTests & {test: v, passValue: passValue_}).result
 			if !(isStructEmpty & {struct: failedTests}).result {
 				"\(k)": failedTests
 			}

--- a/testing.cue
+++ b/testing.cue
@@ -15,11 +15,11 @@ Test: {
 	assert?:                    {
 		ok: _
 		let testResult = ok & subject
-		pass: testResult != _|_
+		pass: (*_|_ | testResult) != _|_
 	} | {
 		notOk: _
 		let testResult = notOk & subject
-		pass: testResult == _|_
+		pass: (*_|_ | testResult) == _|_
 	}
 }
 

--- a/testing.cue
+++ b/testing.cue
@@ -37,14 +37,13 @@ checkTests: {
 				}
 			}
 		}
-		for k, v in test_ {
-			if (k != "assert" && k != "subject") {
-				let failedTests = (checkTests & {test: v, passValue: passValue_}).result
-				if !(isStructEmpty & {struct: failedTests}).result {
-					"\(k)": failedTests
-				}
+		for k, v in test_ if (k != "assert" && k != "subject") {
+			let failedTests = (checkTests & {test: v, passValue: passValue_}).result
+			if !(isStructEmpty & {struct: failedTests}).result {
+				"\(k)": failedTests
 			}
 		}
+
 	}
 }
 

--- a/testing.cue
+++ b/testing.cue
@@ -1,34 +1,34 @@
 package testing
 
-T :: {
+T: {
 	test: Test
-	test_ = test
+	let test_ = test
 	FAIL: (checkTests & {passValue: false, "test": test_}).result
 	PASS: (checkTests & {passValue: true, "test":  test_}).result
 }
 
-NumDot :: =~"^[0-9]+([.]?[0-9])*$"
+NumDot: =~"^[0-9]+([.]?[0-9])*$"
 
-Test :: {
+Test: {
 	subject?:                   _
 	[!="assert" & !="subject"]: Test
 	assert?:                    {
 		ok: _
-		testResult = ok & subject
+		let testResult = ok & subject
 		pass: testResult != _|_
 	} | {
 		notOk: _
-		testResult = notOk & subject
+		let testResult = notOk & subject
 		pass: testResult == _|_
 	}
 }
 
-checkTests :: {
+checkTests: {
 	passValue?: bool
 	test:       Test
 	result: {
-		test_ = test
-		passValue_ = passValue
+		let test_ = test
+		let passValue_ = passValue
 		if (isFieldDefined & {struct: test_, field: "assert"}).result {
 			if test_.assert.pass == passValue_ {
 				assert: test_.assert
@@ -39,7 +39,7 @@ checkTests :: {
 		}
 		for k, v in test_ {
 			if (k != "assert" && k != "subject") {
-				failedTests = (checkTests & {test: v, passValue: passValue_}).result
+				let failedTests = (checkTests & {test: v, passValue: passValue_}).result
 				if !(isStructEmpty & {struct: failedTests}).result {
 					"\(k)": failedTests
 				}
@@ -48,14 +48,14 @@ checkTests :: {
 	}
 }
 
-isFieldDefined :: {
+isFieldDefined: {
 	struct: {...} // set the key we're checking
 	field:        string
 	result:       (struct & {[_]: _ | *_|_})[field] != _|_
 }
 
-isStructEmpty :: {
+isStructEmpty: {
 	struct: {...}
-	testStruct = struct & {[_]: _|_}
+	let testStruct = struct & {[_]: _|_}
 	result: testStruct != _|_
 }


### PR DESCRIPTION
I ran `cue fix` to fix the syntax so things compile again.

However I'm seeing this error now:

```
$ cue version
cue version v0.4.2 darwin/amd64

$ cue eval ./test
structural cycle:
    ./testing.cue:6:9
structural cycle:
    ./testing.cue:42:24
```